### PR TITLE
Fix for broken controller responders

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -22,20 +22,14 @@ class PagesController < ApplicationController
 
   def create
     @page = Page.new(params[:page])
-    if @page.save
-      respond_with(@page, status: :created, location: @page)
-    else
-      respond_with(@page.errors, status: :unprocessable_entity) 
-    end
+    @page.save
+    respond_with @page
   end
 
   def update
     @page = Page.find(params[:id])
-    if @page.update_attributes(params[:page])
-      respond_with(@page)
-    else
-      respond_with(@page.errors, status: :unprocessable_entity)
-    end
+    @page.update_attributes(params[:page])
+    respond_with @page
   end
 
   def destroy

--- a/test/functional/pages_controller_test.rb
+++ b/test/functional/pages_controller_test.rb
@@ -1,7 +1,16 @@
 require 'test_helper'
 
 class PagesControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "POST /pages with an invalid page" do
+    post :create, :format => :json, :page => { :name => "" }
+    assert_equal 422, response.status
+  end
+
+  test "PUT /pages/:id with an invalid page" do
+    page = Page.create! :name => "Dummy page"
+    put :update, :format => :json, :id => page.id, :page => { :name => "" }
+    assert_equal 422, response.status
+    body = JSON.parse(response.body)
+    assert_equal ["can't be blank"], body['name']
+  end
 end


### PR DESCRIPTION
Responders only need to have the model given to them, they take care of
the status code, headers etc.

I've included some tests as well, just to illustrate what I've fixed
here.
